### PR TITLE
Use format string intead of `string` function

### DIFF
--- a/process.go
+++ b/process.go
@@ -53,22 +53,22 @@ func processLine(line []byte, r *Rule) ([]byte, error) {
 	switch r.Type {
 	case TYPE_MATCH:
 		if strings.Contains(strings.TrimSpace(string(line)), r.Match) {
-			coloredLine := palette[r.Color].Sprintf(string(line))
+			coloredLine := palette[r.Color].Sprintf("%s", line)
 			return []byte(coloredLine), nil
 		}
 	case TYPE_REGEXP:
 		if r.regexp.Match(line) {
-			coloredLine := palette[r.Color].Sprintf(string(line))
+			coloredLine := palette[r.Color].Sprintf("%s", line)
 			return []byte(coloredLine), nil
 		}
 	case TYPE_PREFIX:
 		if strings.HasPrefix(strings.TrimSpace(string(line)), r.Match) {
-			coloredLine := palette[r.Color].Sprintf(string(line))
+			coloredLine := palette[r.Color].Sprintf("%s", line)
 			return []byte(coloredLine), nil
 		}
 	case TYPE_SUFFIX:
 		if strings.HasSuffix(strings.TrimSpace(string(line)), r.Match) {
-			coloredLine := palette[r.Color].Sprintf(string(line))
+			coloredLine := palette[r.Color].Sprintf("%s", line)
 			return []byte(coloredLine), nil
 		}
 	default:

--- a/process_test.go
+++ b/process_test.go
@@ -125,6 +125,21 @@ func Test_process(t *testing.T) {
 			},
 			expect: []byte("Foo \x1b[91mBar\x1b[0m \x1b[91mBaz\x1b[0m"),
 		},
+		{
+			name: "color text including `%`",
+			args: args{
+				origLine: []byte("coverage: 94.6% of statements"),
+				rule: []*Rule{
+					&Rule{
+						Target: "line",
+						Type:   "match",
+						Match:  "coverage",
+						Color:  "red",
+					},
+				},
+			},
+			expect: []byte("\x1b[91mcoverage: 94.6% of statements\x1b[0m"),
+		},
 	}
 
 	color.NoColor = false


### PR DESCRIPTION
To avoid garbling `%`